### PR TITLE
Update sarcos.py

### DIFF
--- a/demos/sarcos.py
+++ b/demos/sarcos.py
@@ -71,8 +71,8 @@ def main():
         optimizer = tf.train.AdamOptimizer()
         train = optimizer.minimize(loss)
 
-    init_op = tf.group(tf.initialize_all_variables(),
-                       tf.initialize_local_variables())
+    init_op = tf.group(tf.global_variables_initializer(),
+                       tf.local_variables_initializer())
 
     with tf.Session(config=CONFIG):
         init_op.run()


### PR DESCRIPTION
`initialize_all_variables` and `initialize_local_variables` are deprecated and has been removed 2017-03-02.