### PR TITLE
Feature/#71

### DIFF
--- a/aboleth/__init__.py
+++ b/aboleth/__init__.py
@@ -4,7 +4,7 @@ from .model import elbo, log_prob
 from .layer import (activation, dropout, dense_var, dense_map, input,
                     embed_var, random_fourier, random_arccosine, Matern, RBF,
                     )
-from .ops import stack, concat, slicecat, add, impute
+from .ops import stack, concat, slicecat, add, mean_impute
 from .likelihood import normal, bernoulli, binomial
 from .distributions import (Normal, Gaussian, norm_prior, norm_posterior,
                             gaus_posterior)
@@ -46,5 +46,5 @@ __all__ = (
     'concat',
     'slicecat',
     'add',
-    'impute'
+    'mean_impute'
 )

--- a/aboleth/layer.py
+++ b/aboleth/layer.py
@@ -5,11 +5,12 @@ import tensorflow as tf
 from aboleth.random import seedgen
 from aboleth.distributions import (norm_prior, norm_posterior, gaus_posterior,
                                    kl_qp)
-
+from aboleth import util as util
 
 #
 # Sampling layer
 #
+
 
 def input(name, n_samples=None):
     """Create a input layer.
@@ -121,7 +122,7 @@ def random_fourier(n_features, kernel=None):
 
     def build_random_ff(X):
         # X is a rank 3 tensor, [n_samples, N, D]
-        n_samples, input_dim = _check_dims_rank3(X)
+        n_samples, input_dim = util.check_dims_rank3(X)
 
         # Random weights, copy faster than map here
         P = kernel.weights(input_dim, n_features)
@@ -188,7 +189,7 @@ def random_arccosine(n_features, lenscale=1.0, p=1):
 
     def build_random_ac(X):
         # X is a rank 3 tensor, [n_samples, N, D]
-        n_samples, input_dim = _check_dims_rank3(X)
+        n_samples, input_dim = util.check_dims_rank3(X)
 
         # Random weights
         rand = np.random.RandomState(next(seedgen))
@@ -252,7 +253,7 @@ def dense_var(output_dim, reg=1., full=False, use_bias=True, prior_W=None,
     """
     def build_dense(X):
         # X is a rank 3 tensor, [n_samples, N, D]
-        n_samples, input_dim = _check_dims_rank3(X)
+        n_samples, input_dim = util.check_dims_rank3(X)
         Wdim = (input_dim, output_dim)
         bdim = (output_dim,)
 
@@ -318,7 +319,7 @@ def embed_var(output_dim, n_categories, reg=1., full=False, prior_W=None,
 
     def build_embedding(X):
         # X is a rank 3 tensor, [n_samples, N, 1]
-        n_samples, input_dim = _check_dims_rank3(X)
+        n_samples, input_dim = util.check_dims_rank3(X)
         if input_dim > 1:
             print("embedding X: {}".format(X))
             raise ValueError("X must be a *column* of indices!")
@@ -362,7 +363,7 @@ def dense_map(output_dim, l1_reg=1., l2_reg=1., use_bias=True):
     """
     def build_dense_map(X):
         # X is a rank 3 tensor, [n_samples, N, D]
-        n_samples, input_dim = _check_dims_rank3(X)
+        n_samples, input_dim = util.check_dims_rank3(X)
         Wdim = (input_dim, output_dim)
 
         W = tf.Variable(tf.random_normal(shape=Wdim, seed=next(seedgen)),
@@ -485,15 +486,6 @@ class Matern(RBF):
 def _l1_loss(X):
     l1 = tf.reduce_sum(tf.abs(X))
     return l1
-
-
-def _check_dims_rank3(X):
-    rank = len(X.shape)
-    if rank != 3:
-        raise ValueError("This layer requires rank 3 inputs, got rank {}!"
-                         .format(rank))
-    n_samples, input_dim = X.shape[0], X.shape[2]
-    return int(n_samples), int(input_dim)
 
 
 def _is_dim(X, dims):

--- a/aboleth/util.py
+++ b/aboleth/util.py
@@ -228,6 +228,27 @@ def predict_expected(predictor, feed_dict, n_groups=1, session=None):
     return pred
 
 
+def check_dims_rank3(X):
+    """Inspects a tensor to ensure its rank is 3.
+
+    Parameters
+    ---------
+    X : A tensor
+
+    Returns
+    -------
+    n_samples : the number of samples in the tensor
+    input_dim : the dimensionality of the data
+
+    """
+    rank = len(X.shape)
+    if rank != 3:
+        raise ValueError("This layer requires rank 3 inputs, got rank {}!"
+                         .format(rank))
+    n_samples, input_dim = X.shape[0], X.shape[2]
+    return int(n_samples), int(input_dim)
+
+
 def __data_len(feed_dict):
     N = feed_dict[list(feed_dict.keys())[0]].shape[0]
     return N

--- a/demos/missing_data.py
+++ b/demos/missing_data.py
@@ -31,7 +31,7 @@ datanet = ab.input(name='X_nan', n_samples=LSAMPLES)
 masknet = ab.input(name='M')
 
 net = ab.stack(
-    ab.impute(datanet, masknet),
+    ab.mean_impute(datanet, masknet),
     ab.dropout(0.95),
     ab.dense_map(output_dim=64, l1_reg=0., l2_reg=REG),
     ab.activation(h=tf.nn.relu),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ def make_missing_data():
     mask[N-5:] = True
     x[mask] = 666.
     X = tf.tile(tf.expand_dims(x, 0), [3, 1, 1])
+    X = tf.cast(X, tf.float32)
     return x, mask, X
 
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -142,7 +142,6 @@ def test_add(make_data):
 def test_impute(make_missing_data):
     """Test the impute_mean."""
     _, m, X = make_missing_data
-    X = tf.cast(X, tf.float32)
 
     # This replicates the input layer behaviour
     def data_layer(**kwargs):
@@ -151,7 +150,7 @@ def test_impute(make_missing_data):
     def mask_layer(**kwargs):
         return kwargs['M'], 0.0
 
-    impute = ab.impute(data_layer, mask_layer)
+    impute = ab.mean_impute(data_layer, mask_layer)
 
     F, KL = impute(X=X, M=m)
 


### PR DESCRIPTION
Add mean imputing to Aboleth

This a stochastic mean imput that sits in the ops.py
Takes two layers (a data producing layer and a mask producing layer) and inputs and returns a tensor and a loss.
It calculates the nan_mean of each column in the batch and fills the value into the missing data.
