### PR TITLE
Feature/#140

### DIFF
--- a/aboleth/__init__.py
+++ b/aboleth/__init__.py
@@ -13,7 +13,7 @@ from .impute import (MaskInputLayer, MeanImpute, FixedNormalImpute,
 from .kernels import RBF, Matern, RBFVariational
 from .distributions import (norm_prior, norm_posterior, gaus_posterior)
 from .prediction import sample_mean, sample_percentiles, sample_model
-from .util import (batch, pos, batch_prediction)
+from .util import (batch, inverse_softplus, batch_prediction)
 from .random import set_hyperseed
 
 __all__ = (
@@ -40,7 +40,7 @@ __all__ = (
     'sample_percentiles',
     'sample_model',
     'batch',
-    'pos',
+    'inverse_softplus',
     'batch_prediction',
     'set_hyperseed',
     'InputLayer',

--- a/aboleth/__init__.py
+++ b/aboleth/__init__.py
@@ -13,7 +13,7 @@ from .impute import (MaskInputLayer, MeanImpute, FixedNormalImpute,
 from .kernels import RBF, Matern, RBFVariational
 from .distributions import (norm_prior, norm_posterior, gaus_posterior)
 from .prediction import sample_mean, sample_percentiles, sample_model
-from .util import (batch, inverse_softplus, batch_prediction)
+from .util import (batch, pos_variable, batch_prediction)
 from .random import set_hyperseed
 
 __all__ = (
@@ -40,7 +40,7 @@ __all__ = (
     'sample_percentiles',
     'sample_model',
     'batch',
-    'inverse_softplus',
+    'pos_variable',
     'batch_prediction',
     'set_hyperseed',
     'InputLayer',

--- a/aboleth/distributions.py
+++ b/aboleth/distributions.py
@@ -1,8 +1,7 @@
 """Helper functions for model parameter distributions."""
 import numpy as np
 import tensorflow as tf
-
-from tensorflow.contrib.distributions import MultivariateNormalTriL
+import tensorflow_probability as tfp
 
 from aboleth.util import inverse_softplus, summary_histogram
 from aboleth.random import seedgen
@@ -126,7 +125,7 @@ def gaus_posterior(dim, std0, suffix=None):
     summary_histogram(mu)
     summary_histogram(lflat)
 
-    Q = MultivariateNormalTriL(mu, L)
+    Q = tfp.distributions.MultivariateNormalTriL(mu, L)
     return Q
 
 
@@ -157,13 +156,14 @@ def kl_sum(q, p):
     return kl
 
 
-@tf.distributions.RegisterKL(MultivariateNormalTriL, tf.distributions.Normal)
+@tf.distributions.RegisterKL(tfp.distributions.MultivariateNormalTriL,
+                             tf.distributions.Normal)
 def _kl_gaussian_normal(q, p, name=None):
     """Gaussian-Normal Kullback Leibler divergence calculation.
 
     Parameters
     ----------
-    q : tf.contrib.distributions.MultivariateNormalTriL
+    q : tfp.distributions.MultivariateNormalTriL
         the approximating 'q' distribution(s).
     p : tf.distributions.Normal
         the prior 'p' distribution(s), ``p.scale`` should be a *scalar* value!
@@ -200,7 +200,7 @@ def _kl_gaussian_normal(q, p, name=None):
 
 def _chollogdet(L):
     """Log det of a cholesky, where L is (..., D, D)."""
-    ldiag = tf.maximum(tf.abs(tf.matrix_diag_part(L), JIT))  # keep > 0
+    ldiag = tf.maximum(tf.abs(tf.matrix_diag_part(L)), JIT)  # keep > 0
     logdet = 2. * tf.reduce_sum(tf.log(ldiag))
     return logdet
 

--- a/aboleth/distributions.py
+++ b/aboleth/distributions.py
@@ -4,7 +4,6 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 
 from aboleth.util import inverse_softplus, summary_histogram
-from aboleth.random import seedgen
 
 
 JIT = 1e-15  # cholesky jitter
@@ -56,16 +55,18 @@ def norm_posterior(dim, std0, suffix=None):
 
     Note
     ----
-    This will make tf.Variables on the randomly initialised mean and standard
-    deviation of the posterior. The initialisation of the mean is from a Normal
-    with zero mean, and ``std0`` standard deviation, and the initialisation of
-    the standard deviation is from a gamma distribution with an alpha of
-    ``std0`` and a beta of 1.
+    This will make tf.Variables on the mean standard deviation of the
+    posterior. The initialisation of the mean is zero and the initialisation of
+    the standard deviation is simply ``std0`` for each element.
 
     """
-    # we have different values for each dimension on the first axis
-    mu_0 = np.zeros(dim, dtype=np.float32)
+    assert (np.ndim(std0) == 0) or (np.shape(std0) == dim)
+    mu_0 = tf.zeros(dim)
     mu = tf.Variable(mu_0, name=_add_suffix("W_mu_q", suffix))
+
+    if np.ndim(std0) == 0:
+        std0 = tf.ones(dim) * std0
+
     std = tf.nn.softplus(tf.Variable(inverse_softplus(std0)),
                          name=_add_suffix("W_std_q", suffix))
 
@@ -101,11 +102,10 @@ def gaus_posterior(dim, std0, suffix=None):
 
     Note
     ----
-    This will make tf.Variables on the randomly initialised mean and covariance
-    of the posterior. The initialisation of the mean is from a Normal with zero
-    mean, and ``std0`` standard deviation, and the initialisation of the (lower
-    triangular of the) covariance is from a gamma distribution with an alpha of
-    ``std0`` and a beta of 1.
+    This will make tf.Variables on the mean and covariance of the posterior.
+    The initialisation of the mean is zero, and the initialisation of the
+    (lower triangular of the) covariance is from diagonal matrices with
+    diagonal elements taking the value of `std0`.
 
     """
     o, i = dim
@@ -113,13 +113,12 @@ def gaus_posterior(dim, std0, suffix=None):
     # Optimize only values in lower triangular
     u, v = np.tril_indices(i)
     indices = (u * i + v)[:, np.newaxis]
-    l0 = np.tile(np.eye(i), [o, 1, 1])[:, u, v].T
-    l0 = l0 * tf.random_gamma(alpha=std0, shape=l0.shape, seed=next(seedgen))
+    l0 = (np.tile(np.eye(i) * std0, [o, 1, 1])[:, u, v].T).astype(np.float32)
     lflat = tf.Variable(l0, name=_add_suffix("W_cov_q", suffix))
     Lt = tf.transpose(tf.scatter_nd(indices, lflat, shape=(i * i, o)))
     L = tf.reshape(Lt, (o, i, i))
 
-    mu_0 = tf.random_normal((o, i), stddev=std0, seed=next(seedgen))
+    mu_0 = tf.zeros((o, i))
     mu = tf.Variable(mu_0, name=_add_suffix("W_mu_q", suffix))
 
     summary_histogram(mu)

--- a/aboleth/distributions.py
+++ b/aboleth/distributions.py
@@ -3,7 +3,7 @@ import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
 
-from aboleth.util import inverse_softplus, summary_histogram
+from aboleth.util import pos_variable, summary_histogram
 
 
 JIT = 1e-15  # cholesky jitter
@@ -67,9 +67,7 @@ def norm_posterior(dim, std0, suffix=None):
     if np.ndim(std0) == 0:
         std0 = tf.ones(dim) * std0
 
-    std = tf.nn.softplus(tf.Variable(inverse_softplus(std0)),
-                         name=_add_suffix("W_std_q", suffix))
-
+    std = pos_variable(std0, name=_add_suffix("W_std_q", suffix))
     summary_histogram(mu)
     summary_histogram(std)
 

--- a/aboleth/impute.py
+++ b/aboleth/impute.py
@@ -3,7 +3,7 @@ import tensorflow as tf
 
 from aboleth.baselayers import MultiLayer
 from aboleth.random import seedgen
-from aboleth.util import inverse_softplus, summary_histogram
+from aboleth.util import pos_variable, summary_histogram
 
 
 class MaskInputLayer(MultiLayer):
@@ -253,10 +253,7 @@ class LearnedNormalImpute(ImputeColumnWise):
             name="impute_means"
         )
         std0 = tf.random_gamma(alpha=1., shape=(datadim,), seed=next(seedgen))
-        impute_std = tf.nn.softplus(
-            tf.Variable(inverse_softplus(std0)),
-            name="impute_vars"
-        )
+        impute_std = pos_variable(std0, name="impute_std")
 
         summary_histogram(impute_means)
         summary_histogram(impute_std)

--- a/aboleth/impute.py
+++ b/aboleth/impute.py
@@ -3,7 +3,7 @@ import tensorflow as tf
 
 from aboleth.baselayers import MultiLayer
 from aboleth.random import seedgen
-from aboleth.util import pos, summary_histogram
+from aboleth.util import inverse_softplus, summary_histogram
 
 
 class MaskInputLayer(MultiLayer):
@@ -252,18 +252,16 @@ class LearnedNormalImpute(ImputeColumnWise):
             tf.random_normal(shape=(datadim,), seed=next(seedgen)),
             name="impute_means"
         )
-        impute_var = tf.Variable(
-            tf.random_gamma(alpha=1., shape=(datadim,), seed=next(seedgen)),
+        std0 = tf.random_gamma(alpha=1., shape=(datadim,), seed=next(seedgen))
+        impute_std = tf.nn.softplus(
+            tf.Variable(inverse_softplus(std0)),
             name="impute_vars"
         )
 
         summary_histogram(impute_means)
-        summary_histogram(impute_var)
+        summary_histogram(impute_std)
 
-        self.normal = tf.distributions.Normal(
-            impute_means,
-            tf.sqrt(pos(impute_var))
-        )
+        self.normal = tf.distributions.Normal(impute_means, impute_std)
 
     def _impute_columns(self, X_2D_zero):
         """Return random draws from an iid Normal for imputation."""

--- a/aboleth/initialisers.py
+++ b/aboleth/initialisers.py
@@ -1,7 +1,6 @@
 """Functions for initialising weights or distributions."""
 import numpy as np
 import tensorflow as tf
-from tensorflow.python.ops.init_ops import VarianceScaling
 
 from aboleth.random import seedgen
 from aboleth.util import inverse_softplus, summary_histogram
@@ -30,9 +29,11 @@ def _autonorm_std(n_in, n_out):
 
 _INIT_DICT = {"glorot": tf.glorot_uniform_initializer(seed=next(seedgen)),
               "glorot_trunc": tf.glorot_normal_initializer(seed=next(seedgen)),
-              "autonorm": VarianceScaling(scale=1.0, mode="fan_in",
-                                          distribution="normal",
-                                          seed=next(seedgen))}
+              "autonorm": tf.variance_scaling_initializer(
+                  scale=1.0,
+                  mode="fan_in",
+                  distribution="untruncated_normal",
+                  seed=next(seedgen))}
 
 _PRIOR_DICT = {"glorot": _glorot_std,
                "autonorm": _autonorm_std}
@@ -91,8 +92,6 @@ def initialise_stds(n_in, n_out, init_val, learn_prior, suffix):
         The initial value of the standard deviation
 
     """
-    # assert len(shape) == 2
-
     if isinstance(init_val, str):
         fn = _PRIOR_DICT[init_val]
         std0 = fn(n_in, n_out)

--- a/aboleth/initialisers.py
+++ b/aboleth/initialisers.py
@@ -3,7 +3,7 @@ import numpy as np
 import tensorflow as tf
 
 from aboleth.random import seedgen
-from aboleth.util import inverse_softplus, summary_histogram
+from aboleth.util import pos_variable, summary_histogram
 
 
 def _glorot_std(n_in, n_out):
@@ -100,8 +100,7 @@ def initialise_stds(n_in, n_out, init_val, learn_prior, suffix):
     std0 = np.array(std0).astype(np.float32)
 
     if learn_prior:
-        std = tf.nn.softplus(tf.Variable(inverse_softplus(std0)),
-                             name="prior_std_{}".format(suffix))
+        std = pos_variable(std0, name="prior_std_{}".format(suffix))
         summary_histogram(std)
     else:
         std = std0

--- a/aboleth/initialisers.py
+++ b/aboleth/initialisers.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 from tensorflow.python.ops.init_ops import VarianceScaling
 
 from aboleth.random import seedgen
-from aboleth.util import pos, summary_histogram
+from aboleth.util import inverse_softplus, summary_histogram
 
 
 def _glorot_std(n_in, n_out):
@@ -101,7 +101,8 @@ def initialise_stds(n_in, n_out, init_val, learn_prior, suffix):
     std0 = np.array(std0).astype(np.float32)
 
     if learn_prior:
-        std = tf.Variable(pos(std0), name="prior_std_{}".format(suffix))
+        std = tf.nn.softplus(tf.Variable(inverse_softplus(std0)),
+                             name="prior_std_{}".format(suffix))
         summary_histogram(std)
     else:
         std = std0

--- a/aboleth/kernels.py
+++ b/aboleth/kernels.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 
 from aboleth.random import seedgen
 from aboleth.distributions import norm_posterior, kl_sum
-from aboleth.util import inverse_softplus, summary_histogram
+from aboleth.util import pos_variable, summary_histogram
 
 
 #
@@ -270,10 +270,7 @@ def _init_lenscale(given_lenscale, learn_lenscale, input_dim):
                           np.float32)
 
     if learn_lenscale:
-        lenscale = tf.nn.softplus(
-            tf.Variable(inverse_softplus(given_lenscale)),
-            name="kernel_lenscale"
-        )
+        lenscale = pos_variable(given_lenscale, name="kernel_lenscale")
         summary_histogram(lenscale)
     else:
         lenscale = given_lenscale

--- a/aboleth/kernels.py
+++ b/aboleth/kernels.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 
 from aboleth.random import seedgen
 from aboleth.distributions import norm_posterior, kl_sum
-from aboleth.util import pos, summary_histogram
+from aboleth.util import inverse_softplus, summary_histogram
 
 
 #
@@ -270,7 +270,10 @@ def _init_lenscale(given_lenscale, learn_lenscale, input_dim):
                           np.float32)
 
     if learn_lenscale:
-        lenscale = tf.Variable(pos(given_lenscale), name="kernel_lenscale")
+        lenscale = tf.softplus(
+            tf.Variable(inverse_softplus(given_lenscale)),
+            name="kernel_lenscale"
+            )
         summary_histogram(lenscale)
     else:
         lenscale = given_lenscale

--- a/aboleth/kernels.py
+++ b/aboleth/kernels.py
@@ -270,10 +270,10 @@ def _init_lenscale(given_lenscale, learn_lenscale, input_dim):
                           np.float32)
 
     if learn_lenscale:
-        lenscale = tf.softplus(
+        lenscale = tf.nn.softplus(
             tf.Variable(inverse_softplus(given_lenscale)),
             name="kernel_lenscale"
-            )
+        )
         summary_histogram(lenscale)
     else:
         lenscale = given_lenscale

--- a/aboleth/losses.py
+++ b/aboleth/losses.py
@@ -33,7 +33,7 @@ def elbo(log_likelihood, KL, N):
 
     .. code-block:: python
 
-        noise = tf.nn.softplus(tf.Variable(ab.inverse_softplus(1.0)))
+        noise = ab.pos_variable(1.0)
         likelihood = tf.distributions.Normal(loc=NN, scale=noise)
         log_likelihood = likelihood.log_prob(Y)
 
@@ -92,7 +92,7 @@ def max_posterior(log_likelihood, regulariser):
 
     .. code-block:: python
 
-        noise = tf.nn.softplus(tf.Variable(ab.inverse_softplus(1.0)))
+        noise = ab.pos_variable(1.0)
         likelihood = tf.distributions.Normal(loc=NN, scale=noise)
         log_likelihood = likelihood.log_prob(Y)
 

--- a/aboleth/losses.py
+++ b/aboleth/losses.py
@@ -33,8 +33,8 @@ def elbo(log_likelihood, KL, N):
 
     .. code-block:: python
 
-        noise = tf.Variable(1.0)
-        likelihood = tf.distributions.Normal(loc=NN, scale=ab.pos(noise))
+        noise = tf.nn.softplus(tf.Variable(ab.inverse_softplus(1.0)))
+        likelihood = tf.distributions.Normal(loc=NN, scale=noise)
         log_likelihood = likelihood.log_prob(Y)
 
     where ``NN`` is our neural network, and ``Y`` are our targets.
@@ -92,8 +92,8 @@ def max_posterior(log_likelihood, regulariser):
 
     .. code-block:: python
 
-        noise = tf.Variable(1.0)
-        likelihood = tf.distributions.Normal(loc=NN, scale=ab.pos(noise))
+        noise = tf.nn.softplus(tf.Variable(ab.inverse_softplus(1.0)))
+        likelihood = tf.distributions.Normal(loc=NN, scale=noise)
         log_likelihood = likelihood.log_prob(Y)
 
     where ``NN`` is our neural network, and ``Y`` are our targets.

--- a/aboleth/util.py
+++ b/aboleth/util.py
@@ -5,32 +5,28 @@ import numpy as np
 from aboleth.random import endless_permutations
 
 
-def inverse_softplus(x):
-    r"""Inverse softplus function for initialising values.
+def pos_variable(initial_value, name=None, **kwargs):
+    """Make a tf.Variable that will remain positive.
 
-    This is useful for when we want to constrain a value to be positive using a
-    softplus function, but we wish to specify an exact value for
-    initialisation.
+    Parameters
+    ----------
+    initial_value : float, np.array, tf.Tensor
+        the initial value of the Variable.
+    name : string
+        the name to give the returned tensor.
+    kwargs : dict
+        optional arguments to give the created ``tf.Variable``.
 
-    Examples
-    --------
-    Say we wish a variable to be positive, and have an initial value of 1.,
-    >>> var = tf.nn.softplus(tf.Variable(1.0))
-    >>> with tf.Session() as sess:
-    ...     sess.run(tf.global_variables_initializer())
-    ...     print(var.eval())
-    1.3132616
-
-    If we use this function,
-    >>> var = tf.nn.softplus(tf.Variable(inverse_softplus(1.0)))
-    >>> with tf.Session() as sess:
-    ...     sess.run(tf.global_variables_initializer())
-    ...     print(var.eval())
-    1.0
+    Returns
+    -------
+    var : tf.Tensor
+        a tf.Variable within a Tensor that will remain positive through
+        training.
 
     """
-    x_prime = tf.log(tf.exp(x) - 1.)
-    return x_prime
+    var0 = tf.Variable(_inverse_softplus(initial_value), **kwargs)
+    var = tf.nn.softplus(var0, name=name)
+    return var
 
 
 def batch(feed_dict, batch_size, n_iter=10000, N_=None):
@@ -129,3 +125,31 @@ def summary_histogram(values):
 def __data_len(feed_dict):
     N = feed_dict[list(feed_dict.keys())[0]].shape[0]
     return N
+
+
+def _inverse_softplus(x):
+    r"""Inverse softplus function for initialising values.
+
+    This is useful for when we want to constrain a value to be positive using a
+    softplus function, but we wish to specify an exact value for
+    initialisation.
+
+    Examples
+    --------
+    Say we wish a variable to be positive, and have an initial value of 1.,
+    >>> var = tf.nn.softplus(tf.Variable(1.0))
+    >>> with tf.Session() as sess:
+    ...     sess.run(tf.global_variables_initializer())
+    ...     print(var.eval())
+    1.3132616
+
+    If we use this function,
+    >>> var = tf.nn.softplus(tf.Variable(_inverse_softplus(1.0)))
+    >>> with tf.Session() as sess:
+    ...     sess.run(tf.global_variables_initializer())
+    ...     print(var.eval())
+    1.0
+
+    """
+    x_prime = tf.log(tf.exp(x) - 1.)
+    return x_prime

--- a/demos/imputation.py
+++ b/demos/imputation.py
@@ -17,7 +17,7 @@ logger.setLevel(logging.INFO)
 
 RSEED = 666
 ab.set_hyperseed(RSEED)
-CONFIG = tf.ConfigProto(device_count={'GPU': 1})  # Use GPU ?
+CONFIG = tf.ConfigProto(device_count={'GPU': 0})  # Use GPU ?
 
 FRAC_TEST = 0.1  # Fraction of data to use for hold-out testing
 FRAC_MISSING = 0.2  # Fraction of data that is missing
@@ -34,7 +34,7 @@ METHOD = "LearnedNormalImpute"
 # Optimization
 NEPOCHS = 5  # Number of times to see the data in training
 BSIZE = 100  # Mini batch size
-LSAMPLES = 5  # Number of samples for training
+LSAMPLES = 3  # Number of samples for training
 PSAMPLES = 50  # Number of predictions samples
 
 
@@ -96,7 +96,7 @@ def main():
 
     net = (
         ab.Concat(cat_layers, con_layers) >>
-        ab.Activation(tf.nn.elu) >>
+        ab.Activation(tf.nn.selu) >>
         ab.DenseVariational(output_dim=NCLASSES)
     )
 

--- a/demos/regression.py
+++ b/demos/regression.py
@@ -91,7 +91,7 @@ def main():
     # This is where we build the actual GP model
     with tf.name_scope("Deepnet"):
         phi, kl = net(X=X_)
-        noise = tf.nn.softplus(tf.Variable(ab.inverse_softplus(NOISE)))
+        noise = ab.pos_variable(NOISE)
         ll = tf.distributions.Normal(loc=phi, scale=noise).log_prob(Y_)
         loss = ab.elbo(ll, kl, N)
 

--- a/demos/regression.py
+++ b/demos/regression.py
@@ -35,7 +35,7 @@ batch_size = 10  # mini batch size for stochastric gradients
 config = tf.ConfigProto(device_count={'GPU': 0})  # Use GPU? 0 is no
 
 # Model initialisation
-noise = tf.Variable(1.)  # Likelihood st. dev. initialisation, and learning
+NOISE = 1.  # Likelihood st. dev. initialisation, and learning
 
 # Random Fourier Features
 kern = ab.RBF(learn_lenscale=True)  # keep the length scale positive
@@ -91,7 +91,8 @@ def main():
     # This is where we build the actual GP model
     with tf.name_scope("Deepnet"):
         phi, kl = net(X=X_)
-        ll = tf.distributions.Normal(loc=phi, scale=ab.pos(noise)).log_prob(Y_)
+        noise = tf.nn.softplus(tf.Variable(ab.inverse_softplus(NOISE)))
+        ll = tf.distributions.Normal(loc=phi, scale=noise).log_prob(Y_)
         loss = ab.elbo(ll, kl, N)
 
     # Set up the training graph

--- a/demos/regression_keras.py
+++ b/demos/regression_keras.py
@@ -39,7 +39,7 @@ batch_size = 10  # mini batch size for stochastric gradients
 config = tf.ConfigProto(device_count={'GPU': 0})  # Use GPU? 0 is no
 
 # Model initialisation
-noise = tf.Variable(1.)  # Likelihood st. dev. initialisation, and learning
+NOISE = 1.
 
 
 class WrapperLayer(SampleLayer):
@@ -103,7 +103,8 @@ def main():
     # This is where we build the actual GP model
     with tf.name_scope("Deepnet"):
         phi, reg = net(X=X_)
-        ll = tf.distributions.Normal(loc=phi, scale=ab.pos(noise)).log_prob(Y_)
+        noise = tf.nn.softplus(tf.Variable(ab.inverse_softplus(NOISE)))
+        ll = tf.distributions.Normal(loc=phi, scale=noise).log_prob(Y_)
         loss = ab.max_posterior(ll, reg)
 
     # Set up the trainig graph

--- a/demos/regression_keras.py
+++ b/demos/regression_keras.py
@@ -103,7 +103,7 @@ def main():
     # This is where we build the actual GP model
     with tf.name_scope("Deepnet"):
         phi, reg = net(X=X_)
-        noise = tf.nn.softplus(tf.Variable(ab.inverse_softplus(NOISE)))
+        noise = ab.pos_variable(NOISE)
         ll = tf.distributions.Normal(loc=phi, scale=noise).log_prob(Y_)
         loss = ab.max_posterior(ll, reg)
 

--- a/demos/regression_tutorial.py
+++ b/demos/regression_tutorial.py
@@ -55,7 +55,7 @@ def linear(X, Y):
 
 def bayesian_linear(X, Y):
     """Bayesian Linear Regression."""
-    noise = tf.nn.softplus(tf.Variable(ab.inverse_softplus(1.0)))
+    noise = ab.pos_variable(1.0)
 
     net = (
         ab.InputLayer(name="X", n_samples=n_samples_) >>
@@ -160,7 +160,7 @@ def svr(X, Y):
 
 def gaussian_process(X, Y):
     """Gaussian Process Regression."""
-    noise = tf.nn.softplus(tf.Variable(ab.inverse_softplus(0.5)))
+    noise = ab.pos_variable(.5)
     kern = ab.RBF(learn_lenscale=True)  # learn lengthscale
 
     net = (
@@ -178,14 +178,14 @@ def gaussian_process(X, Y):
 
 def deep_gaussian_process(X, Y):
     """Deep Gaussian Process Regression."""
-    noise = tf.nn.softplus(tf.Variable(ab.inverse_softplus(0.01)))
+    noise = ab.pos_variable(.1)
 
     net = (
         ab.InputLayer(name="X", n_samples=n_samples_) >>
         ab.RandomFourier(n_features=20, kernel=ab.RBF(learn_lenscale=True)) >>
-        ab.DenseVariational(output_dim=5, full=True) >>
+        ab.DenseVariational(output_dim=5, full=False) >>
         ab.RandomFourier(n_features=10, kernel=ab.RBF(1.)) >>
-        ab.DenseVariational(output_dim=1, full=True)
+        ab.DenseVariational(output_dim=1, full=False)
     )
 
     f, kl = net(X=X)

--- a/demos/regression_tutorial.py
+++ b/demos/regression_tutorial.py
@@ -55,7 +55,7 @@ def linear(X, Y):
 
 def bayesian_linear(X, Y):
     """Bayesian Linear Regression."""
-    noise = tf.Variable(1.)  # Likelihood st. dev. initialisation, and learning
+    noise = tf.nn.softplus(tf.Variable(ab.inverse_softplus(1.0)))
 
     net = (
         ab.InputLayer(name="X", n_samples=n_samples_) >>
@@ -63,7 +63,7 @@ def bayesian_linear(X, Y):
     )
 
     f, kl = net(X=X)
-    lkhood = tf.distributions.Normal(loc=f, scale=ab.pos(noise)).log_prob(Y)
+    lkhood = tf.distributions.Normal(loc=f, scale=noise).log_prob(Y)
     loss = ab.elbo(lkhood, kl, N)
 
     return f, loss
@@ -160,7 +160,7 @@ def svr(X, Y):
 
 def gaussian_process(X, Y):
     """Gaussian Process Regression."""
-    noise = tf.Variable(.5)  # Likelihood st. dev. initialisation, and learning
+    noise = tf.nn.softplus(tf.Variable(ab.inverse_softplus(0.5)))
     kern = ab.RBF(learn_lenscale=True)  # learn lengthscale
 
     net = (
@@ -170,7 +170,7 @@ def gaussian_process(X, Y):
     )
 
     f, kl = net(X=X)
-    lkhood = tf.distributions.Normal(loc=f, scale=ab.pos(noise)).log_prob(Y)
+    lkhood = tf.distributions.Normal(loc=f, scale=noise).log_prob(Y)
     loss = ab.elbo(lkhood, kl, N)
 
     return f, loss
@@ -178,7 +178,7 @@ def gaussian_process(X, Y):
 
 def deep_gaussian_process(X, Y):
     """Deep Gaussian Process Regression."""
-    noise = tf.Variable(.01)  # Likelihood st. dev. initialisation
+    noise = tf.nn.softplus(tf.Variable(ab.inverse_softplus(0.01)))
 
     net = (
         ab.InputLayer(name="X", n_samples=n_samples_) >>
@@ -189,7 +189,7 @@ def deep_gaussian_process(X, Y):
     )
 
     f, kl = net(X=X)
-    lkhood = tf.distributions.Normal(loc=f, scale=ab.pos(noise)).log_prob(Y)
+    lkhood = tf.distributions.Normal(loc=f, scale=noise).log_prob(Y)
     loss = ab.elbo(lkhood, kl, N)
 
     return f, loss

--- a/demos/sarcos.py
+++ b/demos/sarcos.py
@@ -80,8 +80,7 @@ def main():
 
     with tf.name_scope("Deepnet"):
         phi, kl = net(X=data['X'])
-        std = tf.nn.softplus(tf.Variable(ab.inverse_softplus(NOISE)),
-                             name="noise")
+        std = ab.pos_variable(NOISE, name="noise")
         ll_f = tf.distributions.Normal(loc=phi, scale=std)
         ll = ll_f.log_prob(data['Y'])
         loss = ab.elbo(ll, kl, N)

--- a/demos/sarcos.py
+++ b/demos/sarcos.py
@@ -80,7 +80,8 @@ def main():
 
     with tf.name_scope("Deepnet"):
         phi, kl = net(X=data['X'])
-        std = ab.pos(tf.Variable(NOISE, name="noise"))
+        std = tf.nn.softplus(tf.Variable(ab.inverse_softplus(NOISE)),
+                             name="noise")
         ll_f = tf.distributions.Normal(loc=phi, scale=std)
         ll = ll_f.log_prob(data['Y'])
         loss = ab.elbo(ll, kl, N)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
     install_requires=[
         'numpy>=1.12.0',
         'scipy>=0.18.1',
-        'tensorflow>=1.4.0',
+        'tensorflow>=1.10.0',
+        'tensorflow-probability>=0.3',
         'six>=1.10.0'
     ],
     extras_require={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,11 +14,11 @@ RAND = np.random.RandomState(SEED)
 
 @pytest.fixture
 def random():
+    """Get a random seed."""
     return RAND
 
 
-@pytest.fixture
-def make_data():
+def data():
     """Make some simple data."""
     N = 100
     x1 = np.linspace(-10, 10, N)
@@ -28,6 +28,12 @@ def make_data():
     Y = np.dot(x, w) + RAND.randn(N, 1)
     X = tf.tile(tf.expand_dims(x, 0), [3, 1, 1])
     return x, Y, X
+
+
+@pytest.fixture
+def make_data():
+    """Make some simple data as a fixture."""
+    return data()
 
 
 @pytest.fixture
@@ -87,7 +93,7 @@ def make_missing_categories():
 @pytest.fixture
 def make_graph():
     """Make the requirements for making a simple tf graph."""
-    x, Y, X = make_data()
+    x, Y, X = data()
 
     layers = ab.stack(
         ab.InputLayer(name='X', n_samples=10),

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1,9 +1,9 @@
 """Test distributions.py functionality."""
 import numpy as np
 import tensorflow as tf
+import tensorflow_probability as tfp
 from scipy.linalg import cho_solve
 from scipy.stats import wishart
-from tensorflow.contrib.distributions import MultivariateNormalTriL
 
 from aboleth.distributions import kl_sum, _chollogdet
 from .conftest import SEED
@@ -49,7 +49,7 @@ def test_kl_gaussian_normal(random):
 
     mu0 = random.randn(*dim).astype(np.float32)
     L0 = random_chol(Dim)
-    q = MultivariateNormalTriL(mu0, L0)
+    q = tfp.distributions.MultivariateNormalTriL(mu0, L0)
 
     mu1 = random.randn(*dim).astype(np.float32)
     std1 = 1.0
@@ -73,11 +73,11 @@ def test_kl_gaussian_gaussian(random):
 
     mu0 = random.randn(*dim).astype(np.float32)
     L0 = random_chol(Dim)
-    q = MultivariateNormalTriL(mu0, L0)
+    q = tfp.distributions.MultivariateNormalTriL(mu0, L0)
 
     mu1 = random.randn(*dim).astype(np.float32)
     L1 = random_chol(Dim)
-    p = MultivariateNormalTriL(mu1, L1)
+    p = tfp.distributions.MultivariateNormalTriL(mu1, L1)
 
     KL = kl_sum(q, p)
     KLr = KLdiv(mu0, L0, mu1, L1)

--- a/tests/test_initialisers.py
+++ b/tests/test_initialisers.py
@@ -44,6 +44,6 @@ def test_initialise_stds(mocker):
     assert std.name == 'prior_std_bar:0'
 
     tc = tf.test.TestCase()
-    with tc.test_session():
-        assert std.initial_value.eval() == 10.0
-
+    with tc.test_session() as sess:
+        sess.run(tf.global_variables_initializer())
+        assert std.eval() == 10.0


### PR DESCRIPTION
closes #140 also fixes tensorflow.contrib.distributions deprecation warnings, and py.test fixture warnings.

This also has a hotfix for the `norm_posterior` initialization. This was only learning a scalar variable for the whole posterior stddev, instead of a variable for each weight. This may have been a regression introduced recently (it seems ok in master).