### PR TITLE
Feature/#196

### DIFF
--- a/aboleth/__init__.py
+++ b/aboleth/__init__.py
@@ -8,8 +8,8 @@ from .layers import (Activation, DropOut, MaxPool2D, Flatten, DenseVariational,
                      Conv2DMAP, InputLayer, RandomFourier, RandomArcCosine)
 from .hlayers import Concat, Sum, PerFeature
 from .impute import (MaskInputLayer, MeanImpute, FixedNormalImpute,
-                     LearnedScalarImpute, LearnedNormalImpute,
-                     ExtraCategoryImpute)
+                     LearnedScalarImpute, FixedScalarImpute,
+                     LearnedNormalImpute, ExtraCategoryImpute)
 from .kernels import RBF, Matern, RBFVariational
 from .distributions import (norm_prior, norm_posterior, gaus_posterior)
 from .prediction import sample_mean, sample_percentiles, sample_model
@@ -52,6 +52,7 @@ __all__ = (
     'MeanImpute',
     'FixedNormalImpute',
     'LearnedScalarImpute',
+    'FixedScalarImpute',
     'LearnedNormalImpute',
     'ExtraCategoryImpute',
     'RBF',

--- a/aboleth/impute.py
+++ b/aboleth/impute.py
@@ -229,6 +229,24 @@ class LearnedScalarImpute(ImputeColumnWise):
 
 
 class FixedScalarImpute(LearnedScalarImpute):
+    r"""Impute the missing values using a scalar for each column.
+
+    Takes two layers, one the returns a data tensor and the other returns a
+    mask layer. Creates a layer that returns a tensor in which the masked
+    values have been imputed with a provided scalar value per colum.
+
+    Parameters
+    ----------
+    datalayer : callable
+        A layer that returns a data tensor. Must be an InputLayer.
+    masklayer : callable
+        A layer that returns a boolean mask tensor where True values are
+        masked. Must be an InputLayer.
+    scalars : float, array-like
+        A scalar or an array of the values with which to impute each data
+        column.
+
+    """
 
     def __init__(self, datalayer, masklayer, scalars):
         """Construct and instance of a RandomGaussImpute operation."""
@@ -294,9 +312,9 @@ class FixedNormalImpute(LearnedNormalImpute):
     masklayer : callable
         A layer that returns a boolean mask tensor where True values are
         masked. Must be of form ``f(**kwargs)``.
-    loc : array-like
+    loc : float, array-like
         A list of the global mean values of each data column
-    scale : array-like
+    scale : float, array-like
         A list of the global standard deviation of each data column
 
     """
@@ -308,7 +326,10 @@ class FixedNormalImpute(LearnedNormalImpute):
         self.scale = scale
 
     def _initialise_variables(self, X):
-        self.normal = tf.distributions.Normal(self.loc, self.scale)
+        D = X.shape[2]
+        mean = tf.ones((D,)) * self.loc
+        std = tf.ones((D,)) * self.scale
+        self.normal = tf.distributions.Normal(mean, std)
 
 
 class ExtraCategoryImpute(ImputeColumnWise):

--- a/aboleth/impute.py
+++ b/aboleth/impute.py
@@ -31,11 +31,12 @@ class MaskInputLayer(MultiLayer):
         return M, 0.0
 
 
-class ImputeOp(MultiLayer):
-    r"""Abstract Base Impute operation. These specialise MultiLayers.
+class ImputeOp3(MultiLayer):
+    r"""Abstract Base Impute operation for rank 3 Tensors (samples, N, D).
 
-    They expect a data InputLayer and a mask InputLayer. They return layers in
-    which the masked values have been imputed.
+    These specialise MultiLayers and they expect a data InputLayer and a mask
+    InputLayer. They return layers in which the masked values have been
+    imputed.
 
     Parameters
     ----------
@@ -48,7 +49,7 @@ class ImputeOp(MultiLayer):
     """
 
     def __init__(self, datalayer, masklayer):
-        """Construct and instance of an ImputeOp operation."""
+        """Construct and instance of an ImputeOp3 operation."""
         self.datalayer = datalayer
         self.masklayer = masklayer
 
@@ -111,7 +112,7 @@ class ImputeOp(MultiLayer):
         pass
 
 
-class ImputeColumnWise(ImputeOp):
+class ImputeColumnWise(ImputeOp3):
     r"""Abstract class for imputing column-wise from a vector or scalar.
 
     This implements ``_impute2D`` and this calls the ``_impute_columns`` method
@@ -225,6 +226,19 @@ class LearnedScalarImpute(ImputeColumnWise):
     def _impute_columns(self, X_2D_zero):
         """Return the learned scalars for imputation."""
         return self.impute_scalars
+
+
+class FixedScalarImpute(LearnedScalarImpute):
+
+    def __init__(self, datalayer, masklayer, scalars):
+        """Construct and instance of a RandomGaussImpute operation."""
+        super().__init__(datalayer, masklayer)
+        self.impute_scalars = scalars
+
+    def _initialise_variables(self, X):
+        """Initialise the impute variables."""
+        datadim = int(X.shape[2])
+        self.impute_scalars *= tf.ones(shape=(datadim,))
 
 
 class LearnedNormalImpute(ImputeColumnWise):

--- a/aboleth/initialisers.py
+++ b/aboleth/initialisers.py
@@ -3,7 +3,7 @@ import numpy as np
 import tensorflow as tf
 
 from aboleth.random import seedgen
-from aboleth.util import pos_variable, summary_histogram
+from aboleth.util import pos_variable, summary_scalar
 
 
 def _glorot_std(n_in, n_out):
@@ -101,7 +101,7 @@ def initialise_stds(n_in, n_out, init_val, learn_prior, suffix):
 
     if learn_prior:
         std = pos_variable(std0, name="prior_std_{}".format(suffix))
-        summary_histogram(std)
+        summary_scalar(std)
     else:
         std = std0
     return std, std0

--- a/aboleth/kernels.py
+++ b/aboleth/kernels.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 
 from aboleth.random import seedgen
 from aboleth.distributions import norm_posterior, kl_sum
-from aboleth.util import pos_variable, summary_histogram
+from aboleth.util import pos_variable, summary_histogram, summary_scalar
 
 
 #
@@ -271,7 +271,10 @@ def _init_lenscale(given_lenscale, learn_lenscale, input_dim):
 
     if learn_lenscale:
         lenscale = pos_variable(given_lenscale, name="kernel_lenscale")
-        summary_histogram(lenscale)
+        if np.size(given_lenscale) == 1:
+            summary_scalar(lenscale)
+        else:
+            summary_histogram(lenscale)
     else:
         lenscale = given_lenscale
 

--- a/aboleth/util.py
+++ b/aboleth/util.py
@@ -110,7 +110,7 @@ def batch_prediction(feed_dict, batch_size):
 def summary_histogram(values):
     """Add a summary histogram to TensorBoard.
 
-    This will add a summary histogram with name ``variable.name + "_hist"``.
+    This will add a summary histogram with name ``variable.name``.
 
     Parameters
     ----------
@@ -118,8 +118,23 @@ def summary_histogram(values):
         the Tensor to add to the summaries.
 
     """
-    name = values.name.replace(':', '_') + "_hist"
+    name = values.name.replace(':', '_')
     tf.summary.histogram(name=name, values=values)
+
+
+def summary_scalar(values):
+    """Add a summary scalar to TensorBoard.
+
+    This will add a summary scalar with name ``variable.name``.
+
+    Parameters
+    ----------
+    values : tf.Variable, tf.Tensor
+        the Tensor to add to the summaries.
+
+    """
+    name = values.name.replace(':', '_')
+    tf.summary.scalar(name=name, tensor=values)
 
 
 def __data_len(feed_dict):

--- a/demos/imputation.py
+++ b/demos/imputation.py
@@ -25,9 +25,10 @@ MISSING_VAL = -666  # Value to indicate missingness
 NCLASSES = 7  # Number of target classes
 
 # Imputation method CHANGE THESE
-# METHOD = None
-METHOD = "LearnedNormalImpute"
+METHOD = None
+# METHOD = "LearnedNormalImpute"
 # METHOD = "FixedNormalImpute"
+# METHOD = "FixedScalarImpute"
 # METHOD = "LearnedScalarImpute"
 # METHOD = "MeanImpute"
 
@@ -72,6 +73,10 @@ def main():
             std = np.ma.std(xm, axis=0).data.astype(np.float32)
             input_layer = ab.FixedNormalImpute(data_input, mask_input, mean,
                                                std)
+        elif METHOD == "FixedScalarImpute":
+            xm = np.ma.array(Xo, mask=mask)
+            mean = np.ma.mean(xm, axis=0).data.astype(np.float32)
+            input_layer = ab.FixedScalarImpute(data_input, mask_input, mean)
         elif METHOD == "MeanImpute":
             input_layer = ab.MeanImpute(data_input, mask_input)
 

--- a/demos/imputation.py
+++ b/demos/imputation.py
@@ -25,12 +25,12 @@ MISSING_VAL = -666  # Value to indicate missingness
 NCLASSES = 7  # Number of target classes
 
 # Imputation method CHANGE THESE
-METHOD = None
+# METHOD = None
 # METHOD = "LearnedNormalImpute"
 # METHOD = "FixedNormalImpute"
 # METHOD = "FixedScalarImpute"
 # METHOD = "LearnedScalarImpute"
-# METHOD = "MeanImpute"
+METHOD = "MeanImpute"
 
 # Optimization
 NEPOCHS = 5  # Number of times to see the data in training

--- a/demos/sarcos.py
+++ b/demos/sarcos.py
@@ -15,7 +15,7 @@ from aboleth.datasets import fetch_gpml_sarcos_data
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-NSAMPLES = 10  # Number of random samples to get from an Aboleth net
+NSAMPLES = 3  # Number of random samples to get from an Aboleth net
 NFEATURES = 500  # Number of random features/bases to use in the approximation
 NOISE = 3.0  # Initial estimate of the observation noise
 
@@ -33,7 +33,8 @@ n_samples_ = tf.placeholder_with_default(NSAMPLES, [])
 net = ab.stack(
     ab.InputLayer(name='X', n_samples=n_samples_),
     ab.RandomFourier(n_features=NFEATURES, kernel=KERNEL),
-    ab.DenseVariational(output_dim=1, full=True)
+    ab.DenseVariational(output_dim=1, full=True, prior_std=1.0,
+                        learn_prior=True)
 )
 
 # Learning and prediction settings

--- a/tests/test_impute.py
+++ b/tests/test_impute.py
@@ -67,6 +67,32 @@ def test_learned_scalar_impute(make_missing_data):
         assert(X_imputed.shape == X.shape)
 
 
+def test_fixed_scalar_impute(make_missing_data):
+    """Test the impute that uses a scalar value to impute for each col."""
+    ab.set_hyperseed(100)
+    _, m, X, _ = make_missing_data
+
+    # This replicates the input layer behaviour
+    def data_layer(**kwargs):
+        return kwargs['X'], 0.0
+
+    def mask_layer(**kwargs):
+        return kwargs['M'], 0.0
+
+    n, N, D = X.shape
+    impute = ab.FixedScalarImpute(data_layer, mask_layer, np.pi)
+
+    F, KL = impute(X=X, M=m)
+
+    tc = tf.test.TestCase()
+    with tc.test_session():
+        tf.global_variables_initializer().run()
+        X_imputed = F.eval()
+        assert KL.eval() == 0.0
+        assert(X_imputed.shape == X.shape)
+        assert np.allclose(X_imputed[:, m], np.pi)
+
+
 def test_fixed_normal_impute(make_missing_data):
     """Test the fixed normal random imputation."""
     ab.set_hyperseed(100)


### PR DESCRIPTION
Small interface tweaks to impute.py, as well as a new imputing method `FixedScalarImpute` as a complement to `LearnedScalarImpute` (this allowed me to test how well these layers perform compared to mean/median imputing etc - they are OK).